### PR TITLE
Add support for queries using Sequel's virtual rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Require `securerandom` explicitly
+* Add support for queries using Sequel's virtual rows
 
 ### 0.5.2 (2016-12-02)
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ rate.body # => {net_price: 140.0, tax_rate: 11.0, gateway: 'pegasus'}
 rate.meta.update(hotel_enabled: false)
 ```
 
-To query, use `Model.where`:
+To query, use `Model.where` (also using Sequel's [virtual row blocks](http://sequel.jeremyevans.net/rdoc/files/doc/virtual_rows_rdoc.html)):
 
 ```ruby
 # Querying by primary index
@@ -174,6 +174,9 @@ rates = Rate.where(hotel_id: 1, room_type: '1 bed', check_in_date: Date.today)
 # Querying by a named index
 rates = Rate.secondary_index.where(hotel_id: 1, gateway: 'pegasus', discount_type: 'geo')
 rates.first[:net_price] # => 130.0
+
+# Query using Sequel's virtual row block (handy for inequality operators)
+rates = Rate.where(hotel_id: 1, room_type: '1 bed') { check_in_date > Date.today }
 ```
 
 To access a cell field that you're not sure has a value, you can use and `Cell#fetch` (`Model#fetch` delegates to the base cell) to get a value from a cell, or a default, e.g.:

--- a/lib/shameless/index.rb
+++ b/lib/shameless/index.rb
@@ -36,10 +36,10 @@ module Shameless
       @model.store.put(table_name, shardable_value, index_values)
     end
 
-    def where(query)
+    def where(query, &block)
       shardable_value = query.fetch(@shard_on).to_i
       query = index_values(query, false)
-      @model.store.where(table_name, shardable_value, query).map {|r| @model.new(r[:uuid]) }
+      @model.store.where(table_name, shardable_value, query, &block).map {|r| @model.new(r[:uuid]) }
     end
 
     def table_name

--- a/lib/shameless/model.rb
+++ b/lib/shameless/model.rb
@@ -99,8 +99,8 @@ module Shameless
       @indices.each(&:create_tables!)
     end
 
-    def where(query)
-      primary_index.where(query)
+    def where(query, &block)
+      primary_index.where(query, &block)
     end
 
     def reject_index_values(values)

--- a/lib/shameless/store.rb
+++ b/lib/shameless/store.rb
@@ -22,8 +22,8 @@ module Shameless
       find_table(table_name, shardable_value).insert(values)
     end
 
-    def where(table_name, shardable_value, query)
-      find_table(table_name, shardable_value).where(query)
+    def where(table_name, shardable_value, query, &block)
+      find_table(table_name, shardable_value).where(query, &block)
     end
 
     def disconnect

--- a/spec/shameless/index_spec.rb
+++ b/spec/shameless/index_spec.rb
@@ -1,5 +1,5 @@
 describe Shameless::Index do
-  it 'allows querying by a named index' do
+  before(:context) do
     build_store do |store|
       Store = store
 
@@ -13,18 +13,38 @@ describe Shameless::Index do
 
         index :foo do
           integer :my_id
+          string :check_in_date
           shard_on :my_id
         end
       end
     end
+  end
 
-    MyModel.put(primary_id: 1, my_id: 1, foo: 'bar')
-
-    instance = MyModel.foo_index.where(my_id: 1).first
-
-    expect(instance[:foo]).to eq('bar')
-
+  after(:context) do
     Object.send(:remove_const, :MyModel)
     Object.send(:remove_const, :Store)
+  end
+
+  let(:today) { Date.today.to_s }
+  let(:tomorrow) { (Date.today + 1).to_s }
+
+  it 'allows querying by a named index' do
+    MyModel.put(primary_id: 1, my_id: 1, foo: 'bar', check_in_date: today)
+    MyModel.put(primary_id: 2, my_id: 1, foo: 'baz', check_in_date: tomorrow)
+
+    results = MyModel.foo_index.where(my_id: 1)
+
+    expect(results.size).to eq(2)
+    expect(results.first[:foo]).to eq('bar')
+  end
+
+  it 'allows querying with block filters' do
+    MyModel.put(primary_id: 1, my_id: 1, check_in_date: today)
+    MyModel.put(primary_id: 2, my_id: 1, check_in_date: tomorrow)
+
+    results = MyModel.foo_index.where(my_id: 1) { |o| o.check_in_date > today }
+
+    expect(results.size).to eq(1)
+    expect(results.first[:check_in_date]).to eq(tomorrow)
   end
 end

--- a/spec/shameless/model_spec.rb
+++ b/spec/shameless/model_spec.rb
@@ -171,6 +171,28 @@ describe Shameless::Model do
     end
   end
 
+  describe '#where' do
+    it 'queries with hash based filter only' do
+      _, model = build_store
+      same_day_rate = model.put(hotel_id: 1, room_type: 'roh', check_in_date: Date.today.to_s, net_rate: 90)
+      model.put(hotel_id: 1, room_type: 'roh', check_in_date: (Date.today + 1).to_s, net_rate: 90)
+
+      result_ids = model.where(hotel_id: 1, check_in_date: Date.today.to_s).map(&:uuid)
+
+      expect(result_ids).to eq([same_day_rate.uuid])
+    end
+
+    it 'queries with block filters' do
+      _, model = build_store
+      model.put(hotel_id: 1, room_type: 'roh', check_in_date: Date.today.to_s, net_rate: 90)
+      advance_rate = model.put(hotel_id: 1, room_type: 'roh', check_in_date: (Date.today + 1).to_s, net_rate: 90)
+
+      result_ids = model.where(hotel_id: 1) { check_in_date > Date.today.to_s }.map(&:uuid)
+
+      expect(result_ids).to eq([advance_rate.uuid])
+    end
+  end
+
   describe '#present?' do
     it 'returns false if base cell does not exist' do
       _, model = build_store


### PR DESCRIPTION
This allows to easily query with inequality operators over the index
columns, e.g. [where](http://sequel.jeremyevans.net/rdoc/classes/Sequel/Dataset.html#method-i-where) { check_in_date > tomorrow }

> Virtual Rows - http://sequel.jeremyevans.net/rdoc/files/doc/virtual_rows_rdoc.html